### PR TITLE
fix: fatal unsafe repository error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,13 @@ runs:
       run: ${{ github.action_path }}/main.py
       shell: bash
 
+    - name: Check if there are changes
+      id: changes
+      run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
+      shell: bash
+
     - name: Create a PR with the updates
-      if: steps.update-packages.outputs.changed == 1
+      if: steps.changes.outputs.changed > 0
       uses: peter-evans/create-pull-request@v3
       with:
         commit-message: Update Python packages


### PR DESCRIPTION
Fix the issue that GH Action is silently failing with `fatal: unsafe repository ('/github/workspace' is owned by someone else)` message.

Solution is based on similar change in https://github.com/woltapp/wolt-python-package-cookiecutter/pull/18/files.